### PR TITLE
Fix: FPS capper not re-enabling after successful anti-AFK action

### DIFF
--- a/AntiAFK-RBX.cpp
+++ b/AntiAFK-RBX.cpp
@@ -1,4 +1,4 @@
-﻿// AntiAFK-RBX.cpp • The best program for AntiAFK and Multi-Instance in Roblox. Or just Roblox Anti-AFK. • By Agzes
+// AntiAFK-RBX.cpp • The best program for AntiAFK and Multi-Instance in Roblox. Or just Roblox Anti-AFK. • By Agzes
 // https://github.com/Agzes/AntiAFK-RBX • \[=_=]/
 
 #define ALPHA   1
@@ -19257,6 +19257,8 @@ void main_thread(bool arg_tray)
                         RestorePreviousWindowWithSmartAltTab(altN);
                     }
                 }
+
+                ResumeFpsCapperAfterAction(wasFpsCapperPaused);
 
                 if (!cancelPendingAction && anyActionPerformed) {
                     QueueStatusBarOverlay(L"Performing anti-AFK action", STATUS_BAR_POST_ACTION_DURATION, wins.front());


### PR DESCRIPTION
PauseFpsCapperBeforeAction() is called before each anti-AFK action cycle, but ResumeFpsCapperAfterAction() was only called on early-exit (g_stopThread) and cancel paths. On the normal successful path, g_isFpsCapperPaused remained true permanently, causing the FPS capper thread to skip all limiting via its Sleep(100)/continue loop.

Added ResumeFpsCapperAfterAction(wasFpsCapperPaused) call after the window restore block, ensuring the FPS limiter re-engages on all execution paths.

(fixed ai, no tested)